### PR TITLE
Fix Xcode 12 compatibility

### DIFF
--- a/uxcam-react-wrapper/RNUxcam.podspec
+++ b/uxcam-react-wrapper/RNUxcam.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.static_framework = true
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'UXCam' , '~> 3.3.0'
 end
 


### PR DESCRIPTION
Compilation fails on Xcode 12 with `Undefined symbols for architecture` errors, due to the React dependency in the podspec.

See the react-native issue here - facebook/react-native#29633