### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ For iOS, you will need to `pod update`  as well:
 
 ```javascript
 import RNUxcam from 'react-native-ux-cam';
+import { Platform } from 'react-native';
 
 RNUxcam.optIntoSchematicRecordings(); // Add this line to enable iOS screen recordings
+if (Platform.OS === 'ios') {
+  RNUxcam.enableAdvancedGestureRecognizers(false);
+}
 RNUxcam.startWithKey('YOUR API KEY');
 ```
 
@@ -112,6 +116,11 @@ import RNUxcam from 'react-native-ux-cam';
 
 // Add this line to enable iOS screen recordings
 RNUxcam.optIntoSchematicRecordings();
+
+// pan responder drags will be interrupted on iOS without this
+if (Platform.OS === 'ios') {
+  RNUxcam.enableAdvancedGestureRecognizers(false);
+}
 
 // Initialize using your app key.
 RNUxcam.startWithKey(key);


### PR DESCRIPTION
Without setting `enableAdvancedGestureRecognizers` to false on ios, drags are completely broken. I can't think of a single app that doesn't use dragging, and so I think it's important to have this.

I spent 15 hours trying to find this bug, and I'd like to keep other people from going through that pain 😅.