### PR TITLE
fix(occlusion): resolve sensitive views after Fabric mounts them

### DIFF
--- a/uxcam-react-wrapper/android/src/main/java/com/uxcam/RNUxcamModuleImpl.java
+++ b/uxcam-react-wrapper/android/src/main/java/com/uxcam/RNUxcamModuleImpl.java
@@ -17,17 +17,9 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableType;
-import com.facebook.react.bridge.UIManager;
-import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.UnexpectedNativeTypeException;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
-import com.facebook.react.uimanager.NativeViewHierarchyManager;
-import com.facebook.react.uimanager.IllegalViewOperationException;
-import com.facebook.react.uimanager.UIBlock;
-import com.facebook.react.uimanager.UIManagerHelper;
-import com.facebook.react.uimanager.UIManagerModule;
-import com.facebook.react.uimanager.common.UIManagerType;
 import com.uxcam.screenshot.model.UXCamBlur;
 import com.uxcam.screenshot.model.UXCamOverlay;
 import com.uxcam.screenshot.model.UXCamOcclusion;
@@ -61,9 +53,11 @@ public class RNUxcamModuleImpl {
     private static final String UXCAM_REACT_PLUGIN_VERSION = "6.0.20";
 
     private final ReactApplicationContext reactContext;
+    private final RNUxViewResolver viewResolver;
 
     public RNUxcamModuleImpl(ReactApplicationContext reactApplicationContext) {
       this.reactContext = reactApplicationContext;
+      this.viewResolver = new RNUxViewResolver(reactApplicationContext);
       UXCam.addVerificationListener(new OnVerificationListener() {
                 @Override
                 public void onVerificationSuccess() {
@@ -263,7 +257,7 @@ public class RNUxcamModuleImpl {
     }
 
     public void occludeSensitiveViewWithGesture(final int id) {
-       findView(id, (new RNUxViewFinder() {
+       viewResolver.resolve(id, (new RNUxViewFinder() {
            @Override
            public void obtainView(View view) {
                UXCam.occludeSensitiveView(view);
@@ -272,7 +266,7 @@ public class RNUxcamModuleImpl {
     }
 
     public void occludeSensitiveViewWithoutGesture(final int id) {
-        findView(id, (new RNUxViewFinder() {
+        viewResolver.resolve(id, (new RNUxViewFinder() {
             @Override
             public void obtainView(View view) {
                 UXCam.occludeSensitiveViewWithoutGesture(view);
@@ -281,7 +275,7 @@ public class RNUxcamModuleImpl {
     }
 
     public void unOccludeSensitiveView(final double id) {
-        findView((int) id, (new RNUxViewFinder() {
+        viewResolver.resolve((int) id, (new RNUxViewFinder() {
             @Override
             public void obtainView(View view) {
                 UXCam.unOccludeSensitiveView(view);
@@ -289,40 +283,8 @@ public class RNUxcamModuleImpl {
         }));
     }
 
-    private void findView(final int tag, RNUxViewFinder viewFinder) {
-        int type = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED ? UIManagerType.FABRIC : UIManagerType.DEFAULT;
-        UIManager uiManager = UIManagerHelper.getUIManager(getReactApplicationContext(), type);
-        assert uiManager != null;
-        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-            // Temporary fix for nullable view on new architecture due to lazy loading
-            UiThreadUtil.runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        View view = uiManager.resolveView(tag);
-                        if (view != null) {
-                            viewFinder.obtainView(view);
-                        }
-                    } catch (IllegalViewOperationException e) {
-                        // Skip occlusion if view no longer exists
-                    }
-                }
-            }, 100);
-        } else {
-            ((UIManagerModule) uiManager).addUIBlock(new UIBlock() {
-                @Override
-                public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
-                    try {
-                        View view = nativeViewHierarchyManager.resolveView(tag);
-                        if (view != null) {
-                            viewFinder.obtainView(view);
-                        }
-                    } catch (IllegalViewOperationException e) {
-                        // Skip occlusion if view no longer exists
-                    }
-                }
-            });
-        }
+    public void invalidate() {
+        viewResolver.invalidate();
     }
 
     public void optInOverall() {

--- a/uxcam-react-wrapper/android/src/newarch/java/com/uxcam/RNUxViewResolver.java
+++ b/uxcam-react-wrapper/android/src/newarch/java/com/uxcam/RNUxViewResolver.java
@@ -1,0 +1,115 @@
+package com.uxcam;
+
+import android.view.View;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.UIManager;
+import com.facebook.react.bridge.UIManagerListener;
+import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.uimanager.IllegalViewOperationException;
+import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.common.UIManagerType;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+final class RNUxViewResolver implements UIManagerListener {
+    private final ReactApplicationContext reactContext;
+    private final Map<Integer, RNUxViewFinder> pendingFinders = new LinkedHashMap<>();
+    private final AtomicBoolean mountItemsScheduled = new AtomicBoolean();
+    private UIManager uiManager;
+
+    RNUxViewResolver(ReactApplicationContext reactContext) {
+        this.reactContext = reactContext;
+    }
+
+    void resolve(final int tag, final RNUxViewFinder viewFinder) {
+        UiThreadUtil.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if (getUIManager() == null) {
+                    return;
+                }
+
+                View view = resolveAttachedView(tag);
+                if (view != null) {
+                    viewFinder.obtainView(view);
+                    return;
+                }
+
+                boolean wasEmpty = pendingFinders.isEmpty();
+                pendingFinders.put(tag, viewFinder);
+                if (wasEmpty) {
+                    uiManager.addUIManagerEventListener(RNUxViewResolver.this);
+                    mountItemsScheduled.set(true);
+                }
+            }
+        });
+    }
+
+    private UIManager getUIManager() {
+        if (uiManager == null) {
+            uiManager = UIManagerHelper.getUIManager(reactContext, UIManagerType.FABRIC);
+        }
+        return uiManager;
+    }
+
+    private View resolveAttachedView(int tag) {
+        try {
+            View view = uiManager.resolveView(tag);
+            return view != null && view.getParent() != null ? view : null;
+        } catch (IllegalViewOperationException ignored) {
+            return null;
+        }
+    }
+
+    private void resolvePendingViews() {
+        Iterator<Map.Entry<Integer, RNUxViewFinder>> iterator = pendingFinders.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<Integer, RNUxViewFinder> entry = iterator.next();
+            View view = resolveAttachedView(entry.getKey());
+            if (view != null) {
+                iterator.remove();
+                entry.getValue().obtainView(view);
+            }
+        }
+
+        if (pendingFinders.isEmpty()) {
+            uiManager.removeUIManagerEventListener(this);
+        }
+    }
+
+    void invalidate() {
+        UiThreadUtil.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                mountItemsScheduled.set(false);
+                pendingFinders.clear();
+                if (uiManager != null) {
+                    uiManager.removeUIManagerEventListener(RNUxViewResolver.this);
+                }
+            }
+        });
+    }
+
+    public void didMountItems(UIManager mountedUIManager) {
+        mountItemsScheduled.set(false);
+        resolvePendingViews();
+    }
+
+    public void didDispatchMountItems(UIManager mountedUIManager) {
+        if (mountItemsScheduled.getAndSet(false)) {
+            resolvePendingViews();
+        }
+    }
+
+    public void willDispatchViewUpdates(UIManager mountedUIManager) {}
+
+    public void willMountItems(UIManager mountedUIManager) {}
+
+    public void didScheduleMountItems(UIManager mountedUIManager) {
+        mountItemsScheduled.set(true);
+    }
+}

--- a/uxcam-react-wrapper/android/src/newarch/java/com/uxcam/RNUxcamModule.java
+++ b/uxcam-react-wrapper/android/src/newarch/java/com/uxcam/RNUxcamModule.java
@@ -27,6 +27,12 @@ public class RNUxcamModule extends NativeRNUxcamSpec {
     }
 
     @Override
+    public void invalidate() {
+        this.impl.invalidate();
+        super.invalidate();
+    }
+
+    @Override
     public void startWithConfiguration(ReadableMap configuration) {
         this.impl.startWithConfiguration(configuration);
     }

--- a/uxcam-react-wrapper/android/src/oldarch/java/com/uxcam/RNUxViewResolver.java
+++ b/uxcam-react-wrapper/android/src/oldarch/java/com/uxcam/RNUxViewResolver.java
@@ -1,0 +1,40 @@
+package com.uxcam;
+
+import android.view.View;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.IllegalViewOperationException;
+import com.facebook.react.uimanager.NativeViewHierarchyManager;
+import com.facebook.react.uimanager.UIBlock;
+import com.facebook.react.uimanager.UIManagerModule;
+
+final class RNUxViewResolver {
+    private final ReactApplicationContext reactContext;
+
+    RNUxViewResolver(ReactApplicationContext reactContext) {
+        this.reactContext = reactContext;
+    }
+
+    void resolve(final int tag, final RNUxViewFinder viewFinder) {
+        UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
+        if (uiManager == null) {
+            return;
+        }
+
+        uiManager.addUIBlock(new UIBlock() {
+            @Override
+            public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+                try {
+                    View view = nativeViewHierarchyManager.resolveView(tag);
+                    if (view != null) {
+                        viewFinder.obtainView(view);
+                    }
+                } catch (IllegalViewOperationException ignored) {
+                }
+            }
+        });
+    }
+
+    void invalidate() {
+    }
+}

--- a/uxcam-react-wrapper/ios/RNUxcam/RNUxcam.mm
+++ b/uxcam-react-wrapper/ios/RNUxcam/RNUxcam.mm
@@ -2,13 +2,13 @@
 #import <UXCam/UXCam.h>
 #import <UXCam/UXCamConfiguration.h>
 #import <UXCam/UXOcclusionHeaders.h>
-#import <React/RCTUIManager.h>
-#import <React/RCTUIManagerUtils.h>
 #import <React/RCTConvert.h>
+#import <React/RCTUIManagerUtils.h>
 
 // Thanks to this guard, we won't import this header when we build for the old architecture.
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "RNUxcamSpec.h"
+#import <React/RCTSurfacePresenterStub.h>
 #endif
 
 static NSString* const RNUxcam_VerifyEvent_Name = @"UXCam_Verification_Event";
@@ -35,9 +35,17 @@ static NSString* const RNUxcam_PluginType = @"react-native";
 static NSString* const RNUxcam_PluginVersion = @"6.0.20";
 
 
+#ifdef RCT_NEW_ARCH_ENABLED
+@interface RNUxcam () <RCTSurfacePresenterObserver>
+#else
 @interface RNUxcam ()
+#endif
 @property (atomic, strong) NSNumber* lastVerifyResult;
 @property (atomic, assign) NSInteger numEventListeners;
+#ifdef RCT_NEW_ARCH_ENABLED
+@property (nonatomic, weak) id<RCTSurfacePresenterStub> surfacePresenter;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSNumber *> *pendingViewOcclusions;
+#endif
 @end
 
 @implementation RNUxcam
@@ -45,6 +53,42 @@ static NSString* const RNUxcam_PluginVersion = @"6.0.20";
 RCT_EXPORT_MODULE();
 
 @synthesize viewRegistry_DEPRECATED = _viewRegistry_DEPRECATED;
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _pendingViewOcclusions = [NSMutableDictionary new];
+    }
+    return self;
+}
+
+- (void)setBridge:(RCTBridge *)bridge
+{
+    [super setBridge:bridge];
+    if (bridge.surfacePresenter) {
+        [self setSurfacePresenter:bridge.surfacePresenter];
+    }
+}
+
+- (void)setSurfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter
+{
+    if (_surfacePresenter == surfacePresenter) {
+        return;
+    }
+
+    [_surfacePresenter removeObserver:self];
+    _surfacePresenter = surfacePresenter;
+    [_surfacePresenter addObserver:self];
+}
+
+- (void)invalidate
+{
+    [_surfacePresenter removeObserver:self];
+    [_pendingViewOcclusions removeAllObjects];
+    [super invalidate];
+}
+#endif
 
 /// TODO: Investigate if we can remove this and run on a general background Q
 - (dispatch_queue_t)methodQueue
@@ -315,29 +359,25 @@ RCT_EXPORT_METHOD(occludeSensitiveScreen:(BOOL)hideScreen hideGestures:(BOOL)hid
 
 RCT_EXPORT_METHOD(occludeSensitiveView:(double)tag hideGestures:(BOOL)hideGestures)
 {
-    RCTExecuteOnUIManagerQueue(^{
-        [self->_viewRegistry_DEPRECATED addUIBlock:^(RCTViewRegistry *viewRegistry) {
-            RCTExecuteOnMainQueue(^{
-                UIView *view = [self->_viewRegistry_DEPRECATED viewForReactTag:@(tag)];
-                // Temporary fix for handling null views in new architecture mode until this is fully migrated to shadow nodes
-                if (![self isViewAvailableAndAttachedToSuperView:view]) {
-                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-                        UIView *view = [self->_viewRegistry_DEPRECATED viewForReactTag:@(tag)];
-                        if ([self isViewAvailableAndAttachedToSuperView:view]) {
-                            [self occludeView:view hideGesture:hideGestures];
-                        }
-                    });
-                } else {
-                    [self occludeView:view hideGesture:hideGestures];
-                }
-            });
-        }];
-    });
-    
-}
+#ifdef RCT_NEW_ARCH_ENABLED
+    NSNumber *reactTag = @(tag);
+    UIView *view = [self->_viewRegistry_DEPRECATED viewForReactTag:reactTag];
+    if (view) {
+        [self occludeView:view hideGesture:hideGestures];
+        return;
+    }
 
-- (BOOL)isViewAvailableAndAttachedToSuperView:(UIView *)view {
-    return view != nil && view.superview != nil;
+    _pendingViewOcclusions[reactTag] = @(hideGestures);
+#else
+    RCTExecuteOnUIManagerQueue(^{
+      [self->_viewRegistry_DEPRECATED addUIBlock:^(RCTViewRegistry *viewRegistry) {
+        UIView *view = [viewRegistry viewForReactTag:@(tag)];
+        if (view) {
+            [self occludeView:view hideGesture:hideGestures];
+        }
+      }];
+    });
+#endif
 }
 
 - (void)occludeView:(UIView *)view hideGesture:(BOOL)hideGesture {
@@ -350,11 +390,32 @@ RCT_EXPORT_METHOD(occludeSensitiveView:(double)tag hideGestures:(BOOL)hideGestur
 
 RCT_EXPORT_METHOD(unOccludeSensitiveView:(double)tag)
 {
+#ifdef RCT_NEW_ARCH_ENABLED
+    [_pendingViewOcclusions removeObjectForKey:@(tag)];
+#endif
     UIView *view = [_viewRegistry_DEPRECATED viewForReactTag:@(tag)];
     if (view) {
         [UXCam unOccludeSensitiveView:view];
     }
 }
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (void)didMountComponentsWithRootTag:(__unused NSInteger)rootTag
+{
+    if (_pendingViewOcclusions.count == 0) {
+        return;
+    }
+
+    for (NSNumber *reactTag in _pendingViewOcclusions.allKeys) {
+        UIView *view = [self->_viewRegistry_DEPRECATED viewForReactTag:reactTag];
+        if (view) {
+            NSNumber *hideGestures = _pendingViewOcclusions[reactTag];
+            [_pendingViewOcclusions removeObjectForKey:reactTag];
+            [self occludeView:view hideGesture:hideGestures.boolValue];
+        }
+    }
+}
+#endif
 
 RCT_EXPORT_METHOD(optInOverall)
 {

--- a/uxcam-react-wrapper/src/UXCam.js
+++ b/uxcam-react-wrapper/src/UXCam.js
@@ -10,6 +10,15 @@ const platform = Platform.OS;
 const platformIOS = platform === "ios" ? true : false;
 const platformAndroid = platform === "android" ? true : false;
 
+function occludeView(sensitiveView, hideGestures) {
+    if (sensitiveView) {
+        const tag = findNodeHandle(sensitiveView);
+        if (tag != null) {
+            UXCamBridge.occludeSensitiveView(tag, hideGestures);
+        }
+    }
+}
+
 export default class UXCam {
     
     static startWithConfiguration(configuration) {
@@ -323,32 +332,19 @@ export default class UXCam {
     }
 
     static occludeSensitiveView(sensitiveView) {
-        if (sensitiveView) {
-            const tag = findNodeHandle(sensitiveView);
-            if (tag) {
-                // Add a small delay to allow the native view to be registered
-                setTimeout(() => {
-                    UXCamBridge.occludeSensitiveView(tag, false);
-                }, 10); 
-            }
-        }
+        occludeView(sensitiveView, false);
     }
 
     static occludeSensitiveViewWithoutGesture(sensitiveView) {
-        if (sensitiveView) {
-            const tag = findNodeHandle(sensitiveView);
-            if (tag) {
-                // Add a small delay to allow the native view to be registered
-                setTimeout(() => {
-                    UXCamBridge.occludeSensitiveView(tag, true);
-                }, 10);
-            }
-        }
+        occludeView(sensitiveView, true);
     }
 
     static unOccludeSensitiveView(view) {
         if (view) {
-            UXCamBridge.unOccludeSensitiveView(findNodeHandle(view));
+            const tag = findNodeHandle(view);
+            if (tag != null) {
+                UXCamBridge.unOccludeSensitiveView(tag);
+            }
         }
     }
 


### PR DESCRIPTION
On the new architecture an occludeSensitiveView call can reach native before Fabric has mounted the target view, so the view lookup fails and the occlusion is silently dropped - the view then records unmasked. The previous workarounds (a 10ms setTimeout in JS, a 100ms delayed post on Android, a 0.1s retry on iOS) only widened the window rather than removing the race.

Resolution is now driven by the platform's own mount callbacks:

iOS observes RCTSurfacePresenterObserver.didMountComponentsWithRootTag:, which fires after every mount transaction. Requests that cannot resolve immediately are held by react tag and retried from that callback. setBridge: only forwards a non-nil surface presenter, because bridgeless installs the presenter via setSurfacePresenter: first and then calls setBridge: with an RCTBridgeProxy whose surfacePresenter is nil - forwarding that would unregister the observer and disable the mechanism.

Android resolves through UIManagerListener.didMountItems. Fabric can preallocate a view before inserting it into the hierarchy, so a view is only accepted once getParent() is non-null; handing the SDK a detached view produces a hierarchy descriptor it cannot replay at capture time. The listener is registered only while requests are pending. On RN versions before 0.72, where didMountItems does not exist, a didScheduleMountItems flag gates a single retry from didDispatchMountItems so idle frames stay free of work.

The Fabric resolver lives in src/newarch and the Paper resolver in src/oldarch: UIManagerListener gained willMountItems/didMountItems only in RN 0.72, and the shared source set must keep compiling against the declared react-native >=0.60 peer range.

Pending requests are cleared and the listener unregistered when the module is invalidated.