### PR TITLE
fix: resumeShortBreakForAnotherApp no longer throws; document Android Maven repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,35 @@ For iOS, you will need to `pod update`  as well:
 
 `cd ios && pod update && cd ..`
 
+### Android
+
+The Android SDK is distributed from UXCam's Maven repository. Autolinking normally picks it up, but if your build fails with
+`Could not find com.uxcam:uxcam:<version>` (common with Expo and some Gradle setups) add the repository to your app:
+
+**Bare React Native** — `android/build.gradle`:
+
+```groovy
+allprojects {
+    repositories {
+        // ...
+        maven { url 'https://sdk.uxcam.com/android/' }
+    }
+}
+```
+
+**Expo** — `app.json` / `app.config.js`, then run `npx expo prebuild`:
+
+```json
+[
+  "expo-build-properties",
+  {
+    "android": {
+      "extraMavenRepos": ["https://sdk.uxcam.com/android/"]
+    }
+  }
+]
+```
+
 > Starting from 5.3.0, we no longer support project with react native version <0.60.0. Use manual linking for older version to add [UXCam](https://github.com/uxcam/ios-sdk/raw/main/UXCam.xcframework.zip) to your project.
 
 > iOS 10 is the lowest version supported for recording sessions, which matches the default minimum version for new React Native projects.

--- a/uxcam-react-wrapper/README.md
+++ b/uxcam-react-wrapper/README.md
@@ -7,6 +7,35 @@ For iOS, you will need to update pod as well:
 
 `cd ios && pod update && cd ..`
 
+### Android
+
+The Android SDK is distributed from UXCam's Maven repository. Autolinking normally picks it up, but if your build fails with
+`Could not find com.uxcam:uxcam:<version>` (common with Expo and some Gradle setups) add the repository to your app:
+
+**Bare React Native** — `android/build.gradle`:
+
+```groovy
+allprojects {
+    repositories {
+        // ...
+        maven { url 'https://sdk.uxcam.com/android/' }
+    }
+}
+```
+
+**Expo** — `app.json` / `app.config.js`, then run `npx expo prebuild`:
+
+```json
+[
+  "expo-build-properties",
+  {
+    "android": {
+      "extraMavenRepos": ["https://sdk.uxcam.com/android/"]
+    }
+  }
+]
+```
+
 >Starting from 5.3.0, we no longer support project with react native version <0.60.0. Use manual linking for older version to add [UXCam](https://github.com/uxcam/ios-sdk/raw/main/UXCam.xcframework.zip) to your project.
 
 >iOS 10 is the lowest version supported for recording sessions, which matches the default minimum version for new React Native projects.

--- a/uxcam-react-wrapper/src/UXCam.js
+++ b/uxcam-react-wrapper/src/UXCam.js
@@ -226,10 +226,13 @@ export default class UXCam {
     }
 
     /**
-     *  @brief Resume after short break. Only used in android, does nothing on iOS
+     *  @deprecated The SDK resumes the session automatically when the app returns to the foreground.
+     *  Call `allowShortBreakForAnotherApp(false)` when your app becomes active again instead.
+     *  This method now delegates to `allowShortBreakForAnotherApp(false)` and will be removed in a future major version.
      */
     static resumeShortBreakForAnotherApp() {
-        UXCamBridge.resumeShortBreakForAnotherApp();
+        console.warn('[UXCam] resumeShortBreakForAnotherApp() is deprecated and will be removed. The session resumes automatically; call allowShortBreakForAnotherApp(false) when the app becomes active instead.');
+        UXCam.allowShortBreakForAnotherApp(false);
     }
 
     /**

--- a/uxcam-react-wrapper/src/index.d.ts
+++ b/uxcam-react-wrapper/src/index.d.ts
@@ -241,7 +241,9 @@ export default class UXCam {
     static allowShortBreakForAnotherApp: (continueSession: boolean | number) => void;
 
     /**
-     *  @brief Resume after short break. Only used in android, does nothing on iOS
+     *  @deprecated The SDK resumes the session automatically when the app returns to the foreground.
+     *  Call `allowShortBreakForAnotherApp(false)` when your app becomes active again instead.
+     *  This method now delegates to `allowShortBreakForAnotherApp(false)` and will be removed in a future major version.
      */
     static resumeShortBreakForAnotherApp: () => void;
 


### PR DESCRIPTION
## Summary

Two small fixes coming out of the open-issue triage:

1. **`resumeShortBreakForAnotherApp()` no longer throws** (#162). The method was exported from `UXCam.js` / `index.d.ts` but had no native counterpart on iOS or Android (it is absent from `NativeRNUxcam.ts`, `RNUxcam.mm` and `RNUxcamModuleImpl.java`), so any call failed with `TypeError: UXCamBridge.resumeShortBreakForAnotherApp is not a function`. It now logs a deprecation warning and delegates to `allowShortBreakForAnotherApp(false)`, which is the documented call when the app comes back to the foreground. Marked `@deprecated` in the type definitions so it can be removed in the next major.
2. **README: Android Maven repository** (#142, #156, likely #192). Documents adding `https://sdk.uxcam.com/android/` for bare RN (`allprojects.repositories`) and Expo (`expo-build-properties` → `extraMavenRepos`) to resolve the recurring `Could not find com.uxcam:uxcam:<version>` build failure. Added to both the repo README and the wrapper README shipped to npm.

No native code or version changes; no CHANGELOG row added since that is done at release time.

## Test plan

- [x] `node --check` on `src/UXCam.js`
- [ ] Old arch (Android + iOS): call `RNUxcam.resumeShortBreakForAnotherApp()` → warning logged, no crash, session continues
- [ ] New arch (TurboModule): same call → no crash
- [ ] TypeScript consumer sees `@deprecated` strikethrough on `resumeShortBreakForAnotherApp`
- [ ] README renders correctly on GitHub

Fixes #162 · Refs #142 #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
